### PR TITLE
Changing the "defaults" property & adding "assignDefaultOptions" method

### DIFF
--- a/src/core/Form.ts
+++ b/src/core/Form.ts
@@ -5,13 +5,13 @@ import { Field, Options, SubmitCallback } from '../types'
 import { isObject } from '../utils'
 import generateDefaultLabel from '../helpers/generateDefaultLabel'
 import generateOptions from '../helpers/generateOptions'
-import defaultsOptions from '../defaults'
+import defaultsOptions from '../default-options'
 
 export class Form {
   /**
    * Defaults options for the Form instance
    */
-  public static defaults: Options = defaultsOptions
+  public static defaultOptions: Options = defaultsOptions
 
   /**
    * determine if the form is on submitting mode
@@ -57,7 +57,7 @@ export class Form {
   /**
    * Options of the Form
    */
-  public $options: Options = Form.defaults
+  public $options: Options = Form.defaultOptions
 
   /**
    * constructor of the class
@@ -69,6 +69,16 @@ export class Form {
     this.assignOptions(options)
       .init(data)
       .resetValues()
+  }
+
+  /**
+   * setting up default options for the Form class in more
+   * convenient way then "Form.defaultOptions.validation.something = something"
+   *
+   * @param options
+   */
+  public static assignDefaultOptions(options: Options = {}): void {
+    Form.defaultOptions = generateOptions(Form.defaultOptions, options)
   }
 
   /**

--- a/src/default-options.ts
+++ b/src/default-options.ts
@@ -1,9 +1,9 @@
+import { Options } from './types'
+
 /**
  * Default options that provide to Form instance
  */
-import { Options } from './types'
-
-const defaults: Options = {
+const defaultOptions: Options = {
   successfulSubmission: {
     clearErrors: true,
     clearTouched: true,
@@ -19,4 +19,4 @@ const defaults: Options = {
   },
 }
 
-export default defaults
+export default defaultOptions

--- a/src/helpers/generateOptions.ts
+++ b/src/helpers/generateOptions.ts
@@ -31,7 +31,7 @@ const assignNewOptions = (
 }
 
 /**
- * generate Options base on the defaults Options and new options
+ * generate Options base on the defaultOptions Options and new options
  *
  * @param defaultOptions
  * @param overwriteOptions

--- a/tests/core/Form.spec.ts
+++ b/tests/core/Form.spec.ts
@@ -1,9 +1,9 @@
 import { Errors } from '../../src/core/Errors'
 import { Validator } from '../../src/core/Validator'
 import { Touched } from '../../src/core/Touched'
-import { Form } from '../../src'
+import { Form } from '../../src/core/Form'
 import generateOptions from '../../src/helpers/generateOptions'
-import defaultOptionsSource from '../../src/defaults'
+import defaultOptionsSource from '../../src/default-options'
 
 jest.mock('../../src/core/Errors')
 jest.mock('../../src/core/Validator')
@@ -364,11 +364,34 @@ describe('Form.ts', () => {
     }
   })
 
-  it('should change the defaults options of the Form', () => {
-    Form.defaults.validation.defaultMessage = ({ label, value }) =>
+  it('should change the defaultOptions options of the Form', () => {
+    Form.defaultOptions.validation.defaultMessage = ({ label, value }) =>
       `${label}: ${value}`
-    Form.defaults.successfulSubmission.clearErrors = false
-    Form.defaults.successfulSubmission.resetValues = false
+    Form.defaultOptions.successfulSubmission.clearErrors = false
+    Form.defaultOptions.successfulSubmission.resetValues = false
+
+    let form = new Form(data)
+
+    expect(
+      form.$options.validation.defaultMessage(
+        { label: 'a', value: 'b', key: 'c' },
+        form
+      )
+    ).toEqual('a: b')
+    expect(form.$options.successfulSubmission.clearErrors).toBe(false)
+    expect(form.$options.successfulSubmission.resetValues).toBe(false)
+  })
+
+  it('should assign defaultOptions to the form', () => {
+    Form.assignDefaultOptions({
+      validation: {
+        defaultMessage: ({ label, value }) => `${label}: ${value}`,
+      },
+      successfulSubmission: {
+        clearErrors: false,
+        resetValues: false,
+      },
+    })
 
     let form = new Form(data)
 

--- a/tests/core/Validator.spec.ts
+++ b/tests/core/Validator.spec.ts
@@ -1,6 +1,6 @@
 import { Form } from '../../src'
 import { Validator } from '../../src/core/Validator'
-import defaultOptions from '../../src/defaults'
+import defaultOptions from '../../src/default-options'
 
 jest.mock('../../src/core/Form')
 

--- a/tests/helpers/generateOptions.spec.ts
+++ b/tests/helpers/generateOptions.spec.ts
@@ -1,5 +1,5 @@
 import generateOptions from '../../src/helpers/generateOptions'
-import defaultOptions from '../../src/defaults'
+import defaultOptions from '../../src/default-options'
 
 describe('generateOptions.ts', () => {
   it('should generate new options object from default options and new options Object', () => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,8 @@
     "outDir": "./lib/",
     "module": "es2015",
     "target": "es2015",
-    "declaration": true
+    "declaration": true,
+    "esModuleInterop": true
   },
   "include": [
     "src/**/*"


### PR DESCRIPTION
- the "defaults" property called now "defaultOptions", also the file that hold all the default options called "default-options"
- adding "assignDefaultOptions" method to make it more easy to change the defaults