### PR TITLE
Adding debounce to validate field when `fieldChanged` is called

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ node_modules
 dist
 coverage
 .rpt2_cache
+examples

--- a/README.md
+++ b/README.md
@@ -207,6 +207,7 @@ Those are the default options
   validation: {
     onFieldBlurred: false, // validate on field blurred
     onFieldChanged: false, // validate on change or input event
+    debouncedValidateFieldTime: 0, //the debounce time for `debouncedValidateField` method, the method is running inside fieldChanged method
     onSubmission: true, // validate on submission
     unsetFieldErrorsOnFieldChange: false, // on change/input event, the errors of the targeted field will be removed
     stopAfterFirstRuleFailed: true, // if the first validation of a specific field will fail it will stop to validate this specific field

--- a/src/default-options.ts
+++ b/src/default-options.ts
@@ -12,6 +12,7 @@ const defaultOptions: Options = {
   validation: {
     onFieldBlurred: false,
     onFieldChanged: false,
+    debounceTimeOnFieldChanged: 0,
     onSubmission: true,
     unsetFieldErrorsOnFieldChange: false,
     stopAfterFirstRuleFailed: true,

--- a/src/default-options.ts
+++ b/src/default-options.ts
@@ -12,7 +12,7 @@ const defaultOptions: Options = {
   validation: {
     onFieldBlurred: false,
     onFieldChanged: false,
-    debounceTimeOnFieldChanged: 0,
+    debouncedValidateFieldTime: 0,
     onSubmission: true,
     unsetFieldErrorsOnFieldChange: false,
     stopAfterFirstRuleFailed: true,

--- a/src/helpers/generateDebouncedValidateField.ts
+++ b/src/helpers/generateDebouncedValidateField.ts
@@ -10,6 +10,6 @@ import { Form } from '../core/Form'
 export default (form: Form): Function => {
   return debounce(
     form.validateField.bind(form),
-    form.$options.validation.debounceTimeOnFieldChanged
+    form.$options.validation.debouncedValidateFieldTime
   )
 }

--- a/src/helpers/generateDebouncedValidateField.ts
+++ b/src/helpers/generateDebouncedValidateField.ts
@@ -1,0 +1,15 @@
+import { debounce } from '../utils'
+import { Form } from '../core/Form'
+
+/**
+ * generate a debounced versions of validate field method
+ * base on form options
+ *
+ * @param form
+ */
+export default (form: Form): Function => {
+  return debounce(
+    form.validateField.bind(form),
+    form.$options.validation.debounceTimeOnFieldChanged
+  )
+}

--- a/src/types/Options.ts
+++ b/src/types/Options.ts
@@ -30,10 +30,11 @@ export interface ValidationOptions {
   onFieldChanged?: boolean
 
   /**
-   * the debounce time (on milliseconds) for `onFieldChanged` event
-   * (only for the validation part)
+   * the debounce time (on milliseconds) for `debounceValidateField` method
+   * this method will be called in `fieldChanged` method if `onFieldChanged`
+   * equals to true
    */
-  debounceTimeOnFieldChanged?: number
+  debouncedValidateFieldTime?: number
 
   /**
    * validate the field on field blurred

--- a/src/types/Options.ts
+++ b/src/types/Options.ts
@@ -30,6 +30,12 @@ export interface ValidationOptions {
   onFieldChanged?: boolean
 
   /**
+   * the debounce time (on milliseconds) for `onFieldChanged` event
+   * (only for the validation part)
+   */
+  debounceTimeOnFieldChanged?: number
+
+  /**
    * validate the field on field blurred
    */
   onFieldBlurred?: boolean

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -15,3 +15,22 @@ export const isObject = (value: any): boolean => {
 export const warn = (message): void => {
   console.error(`[Form-wrapper-js warn]: ${message}`)
 }
+
+/**
+ * debounce function
+ *
+ * @param callback
+ * @param time
+ */
+export const debounce = (callback: Function, time: number): Function => {
+  let interval
+
+  return (...args) => {
+    clearTimeout(interval)
+    interval = setTimeout(() => {
+      interval = null
+
+      callback(...args)
+    }, time)
+  }
+}

--- a/tests/core/Form/Form.events.spec.ts
+++ b/tests/core/Form/Form.events.spec.ts
@@ -19,12 +19,12 @@ describe('Form.events.ts', () => {
       },
     })
 
-    form.validateField = jest.fn()
+    form.debouncedValidateField = jest.fn()
 
     form.fieldChanged('first_name')
 
-    expect(form.validateField).toHaveBeenCalledTimes(1)
-    expect(form.validateField).toHaveBeenCalledWith('first_name')
+    expect(form.debouncedValidateField).toHaveBeenCalledTimes(1)
+    expect(form.debouncedValidateField).toHaveBeenCalledWith('first_name')
 
     form.assignOptions({
       validation: {
@@ -32,9 +32,11 @@ describe('Form.events.ts', () => {
       },
     })
 
+    form.debouncedValidateField = jest.fn()
+
     form.fieldChanged('first_name')
 
-    expect(form.validateField).toHaveBeenCalledTimes(1)
+    expect(form.debouncedValidateField).toHaveBeenCalledTimes(0)
   })
 
   it('should clear field errors after field changed', () => {

--- a/tests/core/Form/Form.spec.ts
+++ b/tests/core/Form/Form.spec.ts
@@ -6,10 +6,17 @@ import generateOptions from '../../../src/helpers/generateOptions'
 import defaultOptionsSource from '../../../src/default-options'
 import { InterceptorManager } from '../../../src/core/InterceptorManager'
 import * as utils from '../../../src/utils'
+import generateDebouncedValidateField from '../../../src/helpers/generateDebouncedValidateField'
 
 jest.mock('../../../src/core/Errors')
 jest.mock('../../../src/core/Validator')
 jest.mock('../../../src/core/Touched')
+jest.mock('../../../src/helpers/generateDebouncedValidateField', () => {
+  return {
+    __esModule: true,
+    default: jest.fn(() => 'fakeResponse'),
+  }
+})
 
 describe('Form.ts', () => {
   interface FormData {
@@ -33,6 +40,8 @@ describe('Form.ts', () => {
   it('should init correctly', () => {
     const rulesArray = [() => true]
     const isDeveloperRulesArray = [() => false]
+
+    const assignOptionsSpy = jest.spyOn(Form.prototype, 'assignOptions')
 
     let form = new Form({
       first_name: {
@@ -80,6 +89,7 @@ describe('Form.ts', () => {
     expect(form.$interceptors.submissionComplete).toBeInstanceOf(
       InterceptorManager
     )
+    expect(assignOptionsSpy).toHaveBeenCalled()
   })
 
   it('should access the form props', () => {
@@ -98,10 +108,15 @@ describe('Form.ts', () => {
     expect(form.$options).toEqual(defaultOptions)
     expect(form.$options.successfulSubmission.clearErrors).toBe(true)
 
-    const newOptions = { successfulSubmission: { clearErrors: false } }
+    const newOptions = {
+      successfulSubmission: { clearErrors: false },
+    }
 
     form.assignOptions(newOptions)
+
     expect(form.$options).toEqual(generateOptions(defaultOptions, newOptions))
+    expect(generateDebouncedValidateField).toHaveBeenLastCalledWith(form)
+    expect(form.debouncedValidateField).toBe('fakeResponse')
   })
 
   it('should returns the values on call', function() {

--- a/tests/helpers/generateDebouncedValidateField.spec.ts
+++ b/tests/helpers/generateDebouncedValidateField.spec.ts
@@ -16,7 +16,7 @@ describe('generateDebouncedValidateField.ts', () => {
     Function.prototype.bind = jest.fn(function() {
       return this
     })
-    form.$options.validation.debounceTimeOnFieldChanged = 500
+    form.$options.validation.debouncedValidateFieldTime = 500
 
     let result = generateDebouncedValidateField(form)
 

--- a/tests/helpers/generateDebouncedValidateField.spec.ts
+++ b/tests/helpers/generateDebouncedValidateField.spec.ts
@@ -1,0 +1,26 @@
+import generateDebouncedValidateField from '../../src/helpers/generateDebouncedValidateField'
+import * as utils from '../../src/utils'
+import { Form } from '../../src/core/Form'
+
+jest.mock('../../src/utils', () => {
+  return {
+    debounce: jest.fn(() => 'example'),
+    isObject: () => false,
+  }
+})
+
+describe('generateDebouncedValidateField.ts', () => {
+  it('should generate a debounced version of validate field method', () => {
+    let form = new Form({ name: null })
+
+    Function.prototype.bind = jest.fn(function() {
+      return this
+    })
+    form.$options.validation.debounceTimeOnFieldChanged = 500
+
+    let result = generateDebouncedValidateField(form)
+
+    expect(result).toBe('example')
+    expect(utils.debounce).toHaveBeenLastCalledWith(form.validateField, 500)
+  })
+})

--- a/tests/utils.spec.ts
+++ b/tests/utils.spec.ts
@@ -1,4 +1,4 @@
-import { isObject, warn } from '../src/utils'
+import { isObject, warn, debounce } from '../src/utils'
 
 describe('utils.js', () => {
   it('should determine if value is object', () => {
@@ -16,5 +16,21 @@ describe('utils.js', () => {
     expect(console.error).toHaveBeenCalledWith(
       '[Form-wrapper-js warn]: random error message'
     )
+  })
+
+  it('should debounce the method', () => {
+    jest.useFakeTimers()
+
+    let callback = jest.fn()
+
+    let debouncedCallback = debounce(callback, 2000)
+    debouncedCallback('argument1', 2)
+
+    expect(callback).toHaveBeenCalledTimes(0)
+
+    jest.runAllTimers()
+
+    expect(callback).toHaveBeenCalledTimes(1)
+    expect(callback).toHaveBeenCalledWith('argument1', 2)
   })
 })


### PR DESCRIPTION
now if using `fieldChanged` method and the option to validate on fieldChanged is on, there is an additional option the let the user chose a debounce time to the validation of the field. (by default the debounce time is 0)

related to #29 