### PR TITLE
feat: `valuesAsFormData` + `valuesAsJson`

### DIFF
--- a/docs/guide/form-submission.md
+++ b/docs/guide/form-submission.md
@@ -49,6 +49,23 @@ On failure the `submit` method throws an exception with 2 properties object.
 - `error` - holds the exception that was throw (or rejected) from the `submit` method promise.
 - `form` - holds the whole form object.
 
+## Files and JSON strings
+
+There are 2 methods that can help you format your fields values:
+
+- The first method, `valuesAsFormData` is useful in cases when you need to submit a form with a file in it, the common way to do so is to send the form with a `Content-Type` header: `multipart/form-data`,
+and sending the form values as `FormData` object. this is where the method comes into action:
+
+```js
+form.submit(() => axios.post('https://example.com/form', form.valuesAsFormData(), {
+  headers: { 'Content-Type': 'multipart/form-data' }
+}))
+```
+
+- The second one,`valuesAsJson` is useful for some HTTP clients that require a raw JSON as a request body. 
+the method is just a shortcut for `JSON.stringify(form.values())`
+
+
 ## Why do I need `submit`?
 
 It seems like `submit` method just uses the callback you provide and nothing more, but in fact `submit` is doing little bit more:

--- a/src/core/Form.ts
+++ b/src/core/Form.ts
@@ -169,6 +169,34 @@ export class Form {
   }
 
   /**
+   * Returns FormData object with the form values,
+   * this one is for the use of file upload and other.
+   */
+  public valuesAsFormData(): FormData {
+    const values = this.values()
+    const formData = new FormData()
+
+    for (let key in values) {
+      let value = values[key]
+
+      if ([undefined, false, null].indexOf(value) > -1) {
+        continue
+      }
+
+      formData.append(key, value)
+    }
+
+    return formData
+  }
+
+  /**
+   * returns the form values as a json string.
+   */
+  public valuesAsJson(): string {
+    return JSON.stringify(this.values())
+  }
+
+  /**
    * fill the Form values with new values.
    * without remove another fields values.
    *

--- a/tests/core/Form/Form.spec.ts
+++ b/tests/core/Form/Form.spec.ts
@@ -134,6 +134,38 @@ describe('Form.ts', () => {
     })
   })
 
+  it('should return form values as FormData object', () => {
+    const form = new Form(data) as Form & { [key: string]: any }
+
+    form.first_name = 'Nevo'
+    form.last_name = null
+    form.is_developer = false
+
+    form.not_real_prop = 'Somthing'
+
+    const formData = form.valuesAsFormData()
+
+    expect(formData).toBeInstanceOf(FormData)
+    expect(formData.get('first_name')).toBe('Nevo')
+    expect(formData.has('last_name')).toBe(false)
+    expect(formData.has('is_developer')).toBe(false)
+    expect(formData.has('not_real_prop')).toBe(false)
+  })
+
+  it('should return form values as JSON', () => {
+    const form = new Form(data) as Form & { [key: string]: any }
+
+    form.first_name = 'Nevo'
+    form.last_name = null
+    form.is_developer = false
+
+    form.not_real_prop = 'Somthing'
+
+    const valueAsJson = form.valuesAsJson()
+
+    expect(valueAsJson).toBe(JSON.stringify(form.values()))
+  })
+
   it('should resetValues the values of the form', () => {
     let form = new Form(data) as Form & FormData
 


### PR DESCRIPTION
closes #41 

Adding 2 more methods to the `Form` class,

- `valuesAsFormData` - will return the form values inside a FormData object.
- `valuesAsJson` - will return the form values in JSON format.