### PR TITLE
refactor: rules system

### DIFF
--- a/docs/guide/validation.md
+++ b/docs/guide/validation.md
@@ -143,6 +143,88 @@ One thing to understand, you must reject with **`RuleValidationError`**! otherwi
 You can use `form.$isValidating('email')` In case that your `Promise` base validating take some time, the function will
 return `true` if the `Promise` base validation is still running and `false` if not.
 
+## Dynamic validation
+
+Dynamic validation is useful when there is a field validation that depend on another field, to solve this problem there are 2 options.
+
+1. **This is the recommended way**, create a function that wraps the validation rule (object or function) inside another validation rule:
+```js
+// This example demonstrates a case that a validation rule is an object and not a function
+
+// In your validation file
+export const userRuleIf = (conditionCallback, rule) => {
+  return {
+    passes: (field, form) => {
+      if (!conditionCallback(field, form)) {
+        return true
+      }
+
+      return rule.passes(field, form)
+    },
+    message: rule.message,
+  }  
+}
+
+// In your vue file
+import { Form } from 'form-wrapper-js'
+import { required, useRuleIf } from '@/form/validation.js'
+
+export default {
+  data() {
+    return {
+      form: new Form({
+        is_developer: false,
+        programing_languages: {
+          value: [],
+          rules: [
+            userRuleIf((field, form) => form.is_developer === true, required),
+          ]
+        }
+      })
+    }
+  },
+  // ...Your vue stuff
+}
+```
+
+Of course, you can extend this function and make it more flexible, one way to do so is to support also function validation rules
+and not only objects.
+
+2. Another way is to rebuild the whole rules for the specific field, you can do so with the method `form.$rules.buildFieldRules('fieldName', [rule, rule])`. 
+   this option is less performance because there is some process that the library does to build those rules into something that the library can use. 
+   but sometimes there are cases that your rule depend on data that lives outside the scope of the Form.
+
+```js
+// In your vue file
+import { Form } from 'form-wrapper-js'
+import { required, useRuleIf } from '@/form/validation.js'
+
+export default {
+  data() {
+    return {
+      is_developer: false,
+      form: new Form({
+        programing_languages: {
+          value: [],
+          rules: []
+        }
+      })
+    }
+  },
+  methods: {
+    switchIsDeveloper(state) {
+      this.is_developer = state
+      
+      this.form.$rules.buildFieldRules(
+        'programing_languages', 
+        state ? [required] : []
+      )
+    } 
+  }
+  // ...Your vue stuff
+}
+```
+
 ## Errors
 
 The errors collector will collect errors each time validating a specific field or the whole form,

--- a/src/core/Form.ts
+++ b/src/core/Form.ts
@@ -2,6 +2,7 @@ import { Errors } from './Errors'
 import { Validator } from './Validator'
 import { FieldKeysCollection } from './FieldKeysCollection'
 import { InterceptorManager } from './InterceptorManager'
+import { RulesManager } from './RulesManager'
 import { isObject, warn } from '../utils'
 import generateDebouncedValidateField from '../helpers/generateDebouncedValidateField'
 import generateDefaultLabel from '../helpers/generateDefaultLabel'
@@ -48,6 +49,11 @@ export class Form {
    * Touched - holds all the fields that was touched
    */
   public $touched: FieldKeysCollection
+
+  /**
+   * RulesManager - hold all the fields rules.
+   */
+  public $rules: RulesManager
 
   /**
    * Holds all the labels of the fields
@@ -443,7 +449,8 @@ export class Form {
     this.$initialValues = originalData
     this.$labels = labels
     this.$extra = extra
-    this.$validator = new Validator(rules, this.$options.validation)
+    this.$rules = new RulesManager(rules, this.$options.validation.defaultMessage)
+    this.$validator = new Validator(this.$rules, this.$options.validation)
     this.$errors = new Errors()
     this.$touched = new FieldKeysCollection()
     this.$interceptors = {

--- a/src/core/Form.ts
+++ b/src/core/Form.ts
@@ -449,7 +449,10 @@ export class Form {
     this.$initialValues = originalData
     this.$labels = labels
     this.$extra = extra
-    this.$rules = new RulesManager(rules, this.$options.validation.defaultMessage)
+    this.$rules = new RulesManager(
+      rules,
+      this.$options.validation.defaultMessage
+    )
     this.$validator = new Validator(this.$rules, this.$options.validation)
     this.$errors = new Errors()
     this.$touched = new FieldKeysCollection()

--- a/src/core/Form.ts
+++ b/src/core/Form.ts
@@ -243,6 +243,7 @@ export class Form {
 
     try {
       await this.$validator.validateField(
+        this.$rules.get(fieldKey),
         this._buildFieldObject(fieldKey),
         this
       )
@@ -453,7 +454,7 @@ export class Form {
       rules,
       this.$options.validation.defaultMessage
     )
-    this.$validator = new Validator(this.$rules, this.$options.validation)
+    this.$validator = new Validator(this.$options.validation)
     this.$errors = new Errors()
     this.$touched = new FieldKeysCollection()
     this.$interceptors = {

--- a/src/core/RulesManager.ts
+++ b/src/core/RulesManager.ts
@@ -1,0 +1,82 @@
+import { RawRule, RulesStack } from '../types/Validator'
+import { Rule } from './Rule'
+import { ValidationOptions } from '../types/Options'
+import generateMessageFunction from '../helpers/generateMessageFunction'
+import { MessageFunction, PassesFunction } from '../types/Errors'
+
+export class RulesManager {
+  /**
+   * All the fields Rules.
+   */
+  private _rules: RulesStack = {}
+
+  /**
+   * Default message for the rules
+   */
+  private readonly _defaultMessage: MessageFunction
+
+  /**
+   * constructor
+   *
+   * @param rules
+   * @param defaultMessage
+   */
+  constructor(rules: Object, defaultMessage: MessageFunction | string) {
+    this._defaultMessage = generateMessageFunction(defaultMessage)
+    this._buildRules(rules)
+  }
+
+  /**
+   * check if field has rules
+   *
+   * @param fieldKey
+   */
+  public has(fieldKey: string): boolean {
+    return this._rules.hasOwnProperty(fieldKey)
+  }
+
+  /**
+   * get the rules of specific filedKey
+   *
+   * @param fieldKey
+   */
+  public get(fieldKey: string): Rule[] {
+    return this._rules[fieldKey]
+  }
+
+  /**
+   * return the whole fields rules
+   */
+  public all(): RulesStack {
+    return this._rules
+  }
+
+  /**
+   * Building a field rules from array of RawRules or PassesFunctions
+   *
+   * @param fieldKey
+   * @param rawRules
+   */
+  public buildFieldRules(
+    fieldKey: string,
+    rawRules: Array<RawRule | PassesFunction>
+  ) {
+    this._rules[fieldKey] = rawRules.map(rawValue =>
+      Rule.buildFromRawValue(rawValue, this._defaultMessage)
+    )
+  }
+
+  /**
+   * building rules object
+   *
+   * @param rules
+   * @private
+   */
+  private _buildRules(rules: Object): RulesManager {
+    Object.keys(rules).forEach(fieldKey => {
+      this.buildFieldRules(fieldKey, rules[fieldKey])
+    })
+
+    return this
+  }
+}

--- a/src/core/RulesManager.ts
+++ b/src/core/RulesManager.ts
@@ -41,6 +41,10 @@ export class RulesManager {
    * @param fieldKey
    */
   public get(fieldKey: string): Rule[] {
+    if (!this.has(fieldKey)) {
+      return []
+    }
+
     return this._rules[fieldKey]
   }
 

--- a/src/core/Validator.ts
+++ b/src/core/Validator.ts
@@ -25,18 +25,11 @@ export class Validator {
   private _options: ValidationOptions
 
   /**
-   * Rules managers - hold all the fields rules.
-   */
-  private _rules: RulesManager
-
-  /**
    * Validator constructor.
    *
-   * @param rules
    * @param options
    */
-  constructor(rules: RulesManager, options: ValidationOptions) {
-    this._rules = rules
+  constructor(options: ValidationOptions) {
     this._options = { ...options }
     this.$validating = new FieldKeysCollection()
   }
@@ -44,23 +37,25 @@ export class Validator {
   /**
    * validate specific field.
    *
+   * @param rules
    * @param field
    * @param form
    */
-  public async validateField(field: Field, form: Form): Promise<any> {
+  public async validateField(
+    rules: Rule[],
+    field: Field,
+    form: Form
+  ): Promise<any> {
     const { key } = field
 
-    if (!this._rules.has(key)) {
-      return Promise.resolve()
-    }
-
     const messages: string[] = []
-    let fieldRulesChain: Rule[] = Array.from(this._rules.get(key))
+    let fieldRulesChain: Rule[] = Array.from(rules)
 
     this.$validating.push(key)
 
     while (fieldRulesChain.length) {
       let fieldRule = fieldRulesChain.shift()
+
       try {
         await fieldRule.validate(field, form)
       } catch (error) {

--- a/src/core/Validator.ts
+++ b/src/core/Validator.ts
@@ -8,16 +8,12 @@ import { Field } from '../types/Field'
 import { RulesStack } from '../types/Validator'
 import { ValidationOptions } from '../types/Options'
 import { MessageFunction } from '../types/Errors'
+import { RulesManager } from './RulesManager'
 
 /**
  * Validator Class
  */
 export class Validator {
-  /**
-   * Holds all the rules
-   */
-  public $rules: RulesStack = {}
-
   /**
    * Holds the current field that the validator is validating
    */
@@ -26,37 +22,23 @@ export class Validator {
   /**
    * Validations options
    */
-  public $options: ValidationOptions
+  private _options: ValidationOptions
 
   /**
-   * constructor
+   * Rules managers - hold all the fields rules.
+   */
+  private _rules: RulesManager
+
+  /**
+   * Validator constructor.
    *
    * @param rules
    * @param options
    */
-  constructor(rules: Object, options: ValidationOptions) {
-    this.$options = { ...options }
+  constructor(rules: RulesManager, options: ValidationOptions) {
+    this._rules = rules
+    this._options = { ...options }
     this.$validating = new FieldKeysCollection()
-
-    this._buildRules(rules)
-  }
-
-  /**
-   * check if field has rules
-   *
-   * @param fieldKey
-   */
-  public has(fieldKey: string): boolean {
-    return this.$rules.hasOwnProperty(fieldKey)
-  }
-
-  /**
-   * get the rules of specific filedKey
-   *
-   * @param fieldKey
-   */
-  public get(fieldKey: string): Rule[] {
-    return this.$rules[fieldKey]
   }
 
   /**
@@ -68,12 +50,12 @@ export class Validator {
   public async validateField(field: Field, form: Form): Promise<any> {
     const { key } = field
 
-    if (!this.has(key)) {
+    if (!this._rules.has(key)) {
       return Promise.resolve()
     }
 
     const messages: string[] = []
-    let fieldRulesChain: Rule[] = Array.from(this.get(key))
+    let fieldRulesChain: Rule[] = Array.from(this._rules.get(key))
 
     this.$validating.push(key)
 
@@ -90,7 +72,7 @@ export class Validator {
 
         messages.push(fieldRule.message(field, form))
 
-        if (this.$options.stopAfterFirstRuleFailed) {
+        if (this._options.stopAfterFirstRuleFailed) {
           fieldRulesChain = []
         }
       }
@@ -101,25 +83,5 @@ export class Validator {
     return messages.length
       ? Promise.reject(new FieldValidationError(messages))
       : Promise.resolve(field)
-  }
-
-  /**
-   * building rules object
-   *
-   * @param rules
-   * @private
-   */
-  private _buildRules(rules: Object): Validator {
-    let defaultMessage: MessageFunction = generateMessageFunction(
-      this.$options.defaultMessage
-    )
-
-    Object.keys(rules).forEach(key => {
-      this.$rules[key] = rules[key].map(rawValue =>
-        Rule.buildFromRawValue(rawValue, defaultMessage)
-      )
-    })
-
-    return this
   }
 }

--- a/tests/core/Form/Form.spec.ts
+++ b/tests/core/Form/Form.spec.ts
@@ -7,9 +7,11 @@ import defaultOptionsSource from '../../../src/default-options'
 import { InterceptorManager } from '../../../src/core/InterceptorManager'
 import * as utils from '../../../src/utils'
 import generateDebouncedValidateField from '../../../src/helpers/generateDebouncedValidateField'
+import { RulesManager } from '../../../src/core/RulesManager'
 
 jest.mock('../../../src/core/Errors')
 jest.mock('../../../src/core/Validator')
+jest.mock('../../../src/core/RulesManager')
 jest.mock('../../../src/core/FieldKeysCollection')
 jest.mock('../../../src/helpers/generateDebouncedValidateField', () => {
   return {
@@ -74,11 +76,17 @@ describe('Form.ts', () => {
         options: [1, 0],
       },
     })
-    expect(Validator).toHaveBeenCalledWith(
+
+    expect(RulesManager).toHaveBeenCalledWith(
       {
         first_name: rulesArray,
         is_developer: isDeveloperRulesArray,
       },
+      defaultOptions.validation.defaultMessage
+    )
+
+    expect(Validator).toHaveBeenCalledWith(
+      form.$rules,
       defaultOptions.validation
     )
     expect(Errors).toHaveBeenCalled()

--- a/tests/core/Form/Form.spec.ts
+++ b/tests/core/Form/Form.spec.ts
@@ -85,10 +85,7 @@ describe('Form.ts', () => {
       defaultOptions.validation.defaultMessage
     )
 
-    expect(Validator).toHaveBeenCalledWith(
-      form.$rules,
-      defaultOptions.validation
-    )
+    expect(Validator).toHaveBeenCalledWith(defaultOptions.validation)
     expect(Errors).toHaveBeenCalled()
     expect(FieldKeysCollection).toHaveBeenCalled()
     expect(form.$interceptors.beforeSubmission).toBeInstanceOf(

--- a/tests/core/Form/Form.validation.spec.ts
+++ b/tests/core/Form/Form.validation.spec.ts
@@ -29,6 +29,7 @@ describe('Form.validation.ts', () => {
       name: ['error'],
     })
     expect(form.$validator.validateField).toBeCalledWith(
+      form.$rules.get('name'),
       { label: 'The Name', value: 'a', key: 'name' },
       form
     )

--- a/tests/core/RulesManager.spec.ts
+++ b/tests/core/RulesManager.spec.ts
@@ -1,0 +1,152 @@
+import defaultOptions from '../../src/default-options'
+import { RulesManager } from '../../src/core/RulesManager'
+import { Rule } from '../../src/core/Rule'
+import { ValidationOptions } from '../../src/types/Options'
+import generateMessageFunction from '../../src/helpers/generateMessageFunction'
+
+jest.mock('../../src/helpers/generateMessageFunction', () => {
+  return {
+    __esModule: true,
+    default: jest.fn(() => () => {}),
+  }
+})
+
+describe('RulesManager.ts', () => {
+  let defaultValidationOptions: ValidationOptions
+  let rules = {
+    first_name: [() => true],
+    last_name: [
+      {
+        passes: () => false,
+        message: 'Invalid',
+      },
+      () => true,
+    ],
+    is_developer: [
+      {
+        passes: ({ value }) => value,
+        message: ({ label, value }) =>
+          `${label} is invalid. the ${value} is incorrect`,
+      },
+      {
+        passes: () => Promise.resolve(),
+        returnsPromise: true,
+      },
+      {
+        passes: () => Promise.reject(),
+        returnsPromise: true,
+      },
+    ],
+  }
+
+  beforeEach(() => {
+    defaultValidationOptions = { ...defaultOptions.validation }
+  })
+
+  it('should construct correctly', () => {
+    let buildFieldRule = jest.spyOn(RulesManager.prototype, 'buildFieldRules')
+
+    let rulesManager = new RulesManager(
+      rules,
+      defaultValidationOptions.defaultMessage
+    )
+
+    expect(rulesManager.get('first_name')).toHaveLength(1)
+    expect(rulesManager.get('last_name')).toHaveLength(2)
+    expect(rulesManager.get('is_developer')).toHaveLength(3)
+
+    expect(generateMessageFunction).toHaveBeenNthCalledWith(
+      1,
+      defaultValidationOptions.defaultMessage
+    )
+
+    expect(buildFieldRule).toHaveBeenCalledTimes(3)
+
+    let callNumber: number = 1
+    Object.keys(rulesManager.all()).forEach(fieldKey => {
+      expect(buildFieldRule).toHaveBeenNthCalledWith(
+        callNumber,
+        fieldKey,
+        rules[fieldKey]
+      )
+      callNumber++
+    })
+  })
+
+  it('should determine if has rule', () => {
+    let rulesManager = new RulesManager(
+      rules,
+      defaultValidationOptions.defaultMessage
+    )
+
+    expect(rulesManager.has('first_name')).toBe(true)
+    expect(rulesManager.has('last_name')).toBe(true)
+    expect(rulesManager.has('is_developer')).toBe(true)
+    expect(rulesManager.has('other')).toBe(false)
+  })
+
+  it('should get the rules of the field key that requested', () => {
+    let rulesManager = new RulesManager(
+      rules,
+      defaultValidationOptions.defaultMessage
+    )
+
+    expect(rulesManager.get('first_name')).toBeInstanceOf(Array)
+    expect(rulesManager.get('last_name')).toBeInstanceOf(Array)
+    expect(rulesManager.get('other')).toBe(undefined)
+  })
+
+  it('should returns all the fields rules', () => {
+    let rulesManager = new RulesManager(
+      rules,
+      defaultValidationOptions.defaultMessage
+    )
+
+    let fieldsRules = rulesManager.all()
+
+    expect(Object.keys(fieldsRules)).toEqual([
+      'first_name',
+      'last_name',
+      'is_developer',
+    ])
+
+    Object.keys(fieldsRules).forEach(function(fieldKey) {
+      expect(fieldsRules[fieldKey]).toBeArray()
+    })
+  })
+
+  it('should build field rules correctly', () => {
+    let rulesManager = new RulesManager(
+      rules,
+      defaultValidationOptions.defaultMessage
+    )
+
+    let buildFromRawValueSpy = jest.spyOn(Rule, 'buildFromRawValue')
+
+    let newRules = [
+      () => true,
+      {
+        passes: () => false,
+        message: 'a',
+      },
+    ]
+
+    rulesManager.buildFieldRules('name', newRules)
+
+    expect(buildFromRawValueSpy).toHaveBeenCalledTimes(2)
+    expect(rulesManager.get('name')).toHaveLength(2)
+
+    let callNumber: number = 1
+
+    rulesManager.get('name').forEach((rule, index) => {
+      expect(rule).toBeInstanceOf(Rule)
+      expect(buildFromRawValueSpy).toHaveBeenNthCalledWith(
+        callNumber,
+        newRules[index],
+        expect.toBeFunction()
+      )
+
+      callNumber++
+    })
+  })
+})

--- a/tests/core/RulesManager.spec.ts
+++ b/tests/core/RulesManager.spec.ts
@@ -92,8 +92,11 @@ describe('RulesManager.ts', () => {
     )
 
     expect(rulesManager.get('first_name')).toBeInstanceOf(Array)
+    expect(rulesManager.get('first_name')).toHaveLength(1)
     expect(rulesManager.get('last_name')).toBeInstanceOf(Array)
-    expect(rulesManager.get('other')).toBe(undefined)
+    expect(rulesManager.get('last_name')).toHaveLength(2)
+    expect(rulesManager.get('other')).toBeInstanceOf(Array)
+    expect(rulesManager.get('other')).toHaveLength(0)
   })
 
   it('should returns all the fields rules', () => {


### PR DESCRIPTION
All the rules now managed by RulesManager and the validator only validate the field with the field rules.

This is letting the user the chance to dynamically change the rules with the `buildFieldRules` method inside the RulesManager.

An example will be:
```js
let form = new Form(
  name: {
    value: null,
    rules: [a, b]
  }
)

form.$rules.buildFieldRules('name', [c, d]) // Now the field 'name' rules are `c` and `d`
```

**TODO:**
- [x] Implements the basic logic of the RulesManager and remove staff from the Validator
- [x] Writing docs about `buildFieldRules` with a basic example