### PR TITLE
refactor: method names prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ export default {
   },
   methods: {
     async submit() {
-      const { response } = await this.form.submit(form => axios.post('some-url', form.values()))
+      const { response } = await this.form.$submit(form => axios.post('some-url', form.$values()))
     }
   },
 }

--- a/docs/guide/README.md
+++ b/docs/guide/README.md
@@ -48,8 +48,8 @@ export default {
   methods: {
     async submit() {
       try {
-        const {response} = await this.form.submit(form =>
-          axios.post('https://example.com/form', form.values())
+        const {response} = await this.form.$submit(form =>
+          axios.post('https://example.com/form', form.$values())
         )
       } catch (e) {}
     },
@@ -110,8 +110,8 @@ export default {
   methods: {
     async submit() {
       try {
-        const response = await this.form.submit(form =>
-          axios.post('https://example.com/form', form.values())
+        const response = await this.form.$submit(form =>
+          axios.post('https://example.com/form', form.$values())
         )
       } catch (e) {}
     },
@@ -119,8 +119,8 @@ export default {
 }
 ```
 
-The Form `submit` method accept a function as it first arguments, the function must return a promise. to explore about more information of
-how you can use the `submit` method take a look at [Form submission](/guide/form-submission.md) section.
+The Form `$submit` method accept a function as it first arguments, the function must return a promise. to explore about more information of
+how you can use the `$submit` method take a look at [Form submission](/guide/form-submission.md) section.
 
 Last thing to do is to bind the `submit` method that we created to the form itself
 

--- a/docs/guide/field-events.md
+++ b/docs/guide/field-events.md
@@ -1,12 +1,12 @@
 # Field events
 
 To get the full power of the library it is recommended to bind 3 event methods to your fields:
-`fieldChanged`, `fieldBlurred` and `fieldFocused`.
+`$fieldChanged`, `$fieldBlurred` and `$fieldFocused`.
 in this section we will cover why do you need those method and how to use them.
 
 ## Field Focused
 
-`fieldFocused` method is useful for 2 things:
+`$fieldFocused` method is useful for 2 things:
 
 - To track which field is on focus
 - To track which field is touched
@@ -14,39 +14,39 @@ in this section we will cover why do you need those method and how to use them.
 ```vue
 <template>
   <div>
-    <input type="text" v-model="form.name" @focus="form.fieldFocused('name')" />
+    <input type="text" v-model="form.name" @focus="form.$fieldFocused('name')" />
     <span v-if="form.$onFocus === 'name'"> Name is on focus </span>
-    <span v-if="form.isTouched('name')"> Name is touched </span>
+    <span v-if="form.$touched.has('name')"> Name is touched </span>
   </div>
 </template>
 ```
 
-As you can see every time `@focus` event is triggered on `name` field, `fieldFocused` method will be invoked with `name` as its' argument.
-then the of `$onFocus` will become `name` and the field also will be marked as `touched`.
+As you can see every time `@focus` event is triggered on `name` field, `$fieldFocused` method will be invoked with `name` as its' argument.
+then the of `$onFocus` will become `name` and the field also will be marked as touched.
 
 ::: warning
-Make sure to read `fieldBlurred` method explanation when you are using `fieldFocused` method to track `$onFocus` property.
+Make sure to read `$fieldBlurred` method explanation when you are using `$fieldFocused` method to track `$onFocus` property.
 :::
 
 ## Field Blurred
 
-`fieldBlurred` method is useful for 2 things:
+`$fieldBlurred` method is useful for 2 things:
 
-- It will release `$onFocus` -  if you will bind `fieldFocused` event without bind `fieldBlurred` event,
-  the field will remain `$onFocus` until you will call `fieldFocused` again.
+- It will release `$onFocus` -  if you will bind `EfieldFocused` event without bind `$fieldBlurred` event,
+  the field will remain `$onFocus` until you will call `$fieldFocused` again.
 - It will validate the field if declared in the [options](/guide/options)
 
 ```vue
 <template>
   <div>
-    <input type="text" v-model="form.name" @blur="form.fieldBlurred('name')" />
+    <input type="text" v-model="form.name" @blur="form.$fieldBlurred('name')" />
   </div>
 </template>
 ```
 
 ## Field Changed
 
-`fieldChange` is a general method for 2 possible events, 
+`$fieldChange` is a general method for 2 possible events, 
 for some elements `onChange` event will be suitable and for another `onInput`.
 
 The method is useful for 2 things:
@@ -57,8 +57,8 @@ The method is useful for 2 things:
 ```vue
 <template>
   <div>
-    <input type="text" v-model="form.name" @input="form.fieldChanged('name')" />
-    <select v-model="form.type" @change="form.fieldChanged('type')">
+    <input type="text" v-model="form.name" @input="form.$fieldChanged('name')" />
+    <select v-model="form.type" @change="form.$fieldChanged('type')">
       <!-- options.... -->
     </select>
   </div>
@@ -79,13 +79,13 @@ const form = new Form({
 
 form.name = 'Nevo +'
 
-form.isDirty('name') // returns true
-form.isDirty('last_name') // returns false
+form.$isDirty('name') // returns true
+form.$isDirty('last_name') // returns false
 
-form.isDirty() // returns true
+form.$isDirty() // returns true
 ```
 
-When you pass an argument to the `isDirty` method it checks the field key that you passed to it, but if you call the 
+When you pass an argument to the `$isDirty` method it checks the field key that you passed to it, but if you call the 
 method without arguments it will check the whole form and then return `true` if at least one field is `dirty`.
 
 

--- a/docs/guide/form-submission.md
+++ b/docs/guide/form-submission.md
@@ -53,17 +53,17 @@ On failure the `$submit` method throws an exception with 2 properties object.
 
 There are 2 methods that can help you format your fields values:
 
-- The first method, `valuesAsFormData` is useful in cases when you need to submit a form with a file in it, the common way to do so is to send the form with a `Content-Type` header: `multipart/form-data`,
+- The first method, `$valuesAsFormData` is useful in cases when you need to submit a form with a file in it, the common way to do so is to send the form with a `Content-Type` header: `multipart/form-data`,
 and sending the form values as `FormData` object. this is where the method comes into action:
 
 ```js
-form.submit(() => axios.post('https://example.com/form', form.valuesAsFormData(), {
+form.$submit(() => axios.post('https://example.com/form', form.$valuesAsFormData(), {
   headers: { 'Content-Type': 'multipart/form-data' }
 }))
 ```
 
-- The second one,`valuesAsJson` is useful for some HTTP clients that require a raw JSON as a request body. 
-the method is just a shortcut for `JSON.stringify(form.values())`
+- The second one,`$valuesAsJson` is useful for some HTTP clients that require a raw JSON as a request body. 
+the method is just a shortcut for `JSON.stringify(form.$values())`
 
 
 ## Why do I need `$submit`?

--- a/docs/guide/form-submission.md
+++ b/docs/guide/form-submission.md
@@ -27,8 +27,8 @@ export default {
   methods: {
     async submit() {
       try {
-        const { response, form } = await this.form.submit(form =>
-          axios.post('https://example.com/form', form.values())
+        const { response, form } = await this.form.$submit(form =>
+          axios.post('https://example.com/form', form.$values())
         )
       } catch ({ error, form }) {}
     },
@@ -37,16 +37,16 @@ export default {
 </script>
 ```
 
-In this code snippet we are using 'axios' but `submit` method accept any method that returns a `Promise`.
+In this code snippet we are using 'axios' but `$submit` method accept any method that returns a `Promise`.
 
-On successful submission the `submit` method resolves an object with 2 properties.
+On successful submission the `$submit` method resolves an object with 2 properties.
 
-- `response` - holds the resolved data from your `submit` method.
+- `response` - holds the resolved data from your `$submit` method.
 - `form` - holds the whole form object 
 
-On failure the `submit` method throws an exception with 2 properties object.
+On failure the `$submit` method throws an exception with 2 properties object.
 
-- `error` - holds the exception that was throw (or rejected) from the `submit` method promise.
+- `error` - holds the exception that was throw (or rejected) from the `$submit` method promise.
 - `form` - holds the whole form object.
 
 ## Files and JSON strings
@@ -66,13 +66,13 @@ form.submit(() => axios.post('https://example.com/form', form.valuesAsFormData()
 the method is just a shortcut for `JSON.stringify(form.values())`
 
 
-## Why do I need `submit`?
+## Why do I need `$submit`?
 
-It seems like `submit` method just uses the callback you provide and nothing more, but in fact `submit` is doing little bit more:
+It seems like `$submit` method just uses the callback you provide and nothing more, but in fact `$submit` is doing little bit more:
 
 - `$submitting` property become `true` when the user is sending the `Form` and turn to `false` when the submission is finished.
 - By default the form is validating itself before any submission and do not send the request if the validation failed. (can be changed via [options](/guide/options)).
-- By default the form clears the `errors`, the field `values` and the `touched` array after submission. (can be changed via [options](/guide/options)).
+- By default the form clears the `$errors`, the field `values` and the `$touched` array after submission. (can be changed via [options](/guide/options)).
 
  In the next section there is an explanation about [interceptors](/guide/interceptors), this is another reason you should 
- use the `submit` method.
+ use the `$submit` method.

--- a/docs/guide/interceptors.md
+++ b/docs/guide/interceptors.md
@@ -4,10 +4,10 @@ Before we started, this module inspired by [axios](https://github.com/axios), so
 
 ## What `interceptors` are?
 
-`interceptors` are basically methods that are injected into the submission process, some of them comes before the submission and some of them comes after.
-the library letting creates your custom `interceptors`. here are some basic examples.
+`$interceptors` are basically methods that are injected into the submission process, some of them comes before the submission and some of them comes after.
+the library letting creates your custom `$interceptors`. here are some basic examples.
 
-Let say your server side endpoint returns an errors on submission and you wants to `fill` the `$error` property with those errors,
+Let say your server side endpoint returns an errors on submission and you wants to `fill` the `$errors` property with those errors,
 the simple solution is to doing something like that:
 
 ```js
@@ -17,7 +17,7 @@ export default {
   methods: {
     async submit() {
       try {
-        await this.form.submit(
+        await this.form.$submit(
           () => axios(
             // ...
           )
@@ -32,7 +32,7 @@ export default {
 }
 ```
 
-This behavior can be repeat from form to form, to prevent this duplication we can use `interceptors`.
+This behavior can be repeat from form to form, to prevent this duplication we can use `$interceptors`.
 
 ```js
 // /form/Form.js
@@ -51,7 +51,7 @@ Form.defaults.interceptors.submissionComplete.use(
 export default {
   methods: {
     async submit() {
-      await this.form.submit(
+      await this.form.$submit(
         () => axios(
           // ...
         )

--- a/docs/guide/options.md
+++ b/docs/guide/options.md
@@ -25,7 +25,7 @@ const form = new Form(
 ```js
 const form = new Form({ name: null })
 
-form.assignOptions({
+form.$assignOptions({
   // override options object
 })
 
@@ -49,7 +49,7 @@ Form.defaults.options.validation.onFieldChanged = true // change specific defaul
 ## Default options
 
 This deceleration snippet was taken from the code itself. you can overview the whole 
-`options` object and the default values of it.
+`$options` object and the default values of it.
 
 ```js
 export default {
@@ -115,6 +115,6 @@ export default {
 
 ::: warning
 
-- `validation.onFieldChange` - will work only if the [field event `fieldChange`](/guide/field-events.md) was bounded to the field element.
-- `validation.onFieldBlurred` - will work only if the [field event `fieldBlurred`](/guide/field-events.md) was bounded to the field element.
+- `validation.onFieldChange` - will work only if the [field event `$fieldChange`](/guide/field-events.md) was bounded to the field element.
+- `validation.onFieldBlurred` - will work only if the [field event `$fieldBlurred`](/guide/field-events.md) was bounded to the field element.
   :::

--- a/docs/guide/validation.md
+++ b/docs/guide/validation.md
@@ -49,8 +49,8 @@ there are the 2 "shapes" of validation rule:
 By default the validation runs on submission. you can tweak out the [options](/guide/options) and make your validation runs on field input event or on field blurred event 
 and also you can call the validation manually:
 
-- `form.validate()` - will validate the whole form
-- `form.validate('name')` - will validate only `name` field
+- `form.$validate()` - will validate the whole form
+- `form.$validate('name')` - will validate only `name` field
 
 check out the [options](/guide/options) before starting to use those methods.
 :::
@@ -140,7 +140,7 @@ return a rejected promise with `RuleValidationError`
 One thing to understand, you must reject with **`RuleValidationError`**! otherwise the error will bubble up.
 :::
 
-You can use `form.isValidating('email')` In case that your `Promise` base validating take some time, the function will
+You can use `form.$isValidating('email')` In case that your `Promise` base validating take some time, the function will
 return `true` if the `Promise` base validation is still running and `false` if not.
 
 ## Errors

--- a/src/core/Form.ts
+++ b/src/core/Form.ts
@@ -93,9 +93,9 @@ export class Form {
    * @param options
    */
   constructor(data: Object, options: Options = {}) {
-    this.assignOptions(options)
+    this.$assignOptions(options)
       ._init(data)
-      .resetValues()
+      .$resetValues()
   }
 
   /**
@@ -113,7 +113,7 @@ export class Form {
    *
    * @param options
    */
-  public assignOptions(options: Options) {
+  public $assignOptions(options: Options) {
     this.$options = generateOptions(this.$options, options)
     this.debouncedValidateField = generateDebouncedValidateField(this)
 
@@ -125,14 +125,14 @@ export class Form {
    *
    * @param fieldKey
    */
-  public hasField(fieldKey: string): boolean {
+  public $hasField(fieldKey: string): boolean {
     return this.hasOwnProperty(fieldKey)
   }
 
   /**
    * Set all the fields value same as $initialValues fields value
    */
-  public resetValues(): Form {
+  public $resetValues(): Form {
     for (let fieldName in this.$initialValues) {
       if (this.$initialValues.hasOwnProperty(fieldName)) {
         this[fieldName] = this.$initialValues[fieldName]
@@ -145,8 +145,8 @@ export class Form {
   /**
    * reset the form state (values, errors and touched)
    */
-  public reset(): Form {
-    this.resetValues()
+  public $reset(): Form {
+    this.$resetValues()
     this.$errors.clear()
     this.$touched.clear()
 
@@ -156,11 +156,11 @@ export class Form {
   /**
    * get all the values of the form
    */
-  public values(): Object {
+  public $values(): Object {
     let dataObj = {}
 
     Object.keys(this.$initialValues).forEach(fieldKey => {
-      if (this.hasField(fieldKey)) {
+      if (this.$hasField(fieldKey)) {
         dataObj[fieldKey] = this[fieldKey]
       }
     })
@@ -202,9 +202,9 @@ export class Form {
    *
    * @param newData
    */
-  public fill(newData: Object): Form {
+  public $fill(newData: Object): Form {
     for (let fieldName in newData) {
-      if (newData.hasOwnProperty(fieldName) && this.hasField(fieldName)) {
+      if (newData.hasOwnProperty(fieldName) && this.$hasField(fieldName)) {
         this[fieldName] = newData[fieldName]
       }
     }
@@ -217,8 +217,8 @@ export class Form {
    *
    * @param fieldKey
    */
-  public validate(fieldKey: string | null = null): Promise<any> {
-    return fieldKey ? this.validateField(fieldKey) : this.validateAll()
+  public $validate(fieldKey: string | null = null): Promise<any> {
+    return fieldKey ? this.$validateField(fieldKey) : this.$validateAll()
   }
 
   /**
@@ -226,8 +226,8 @@ export class Form {
    *
    * @param fieldKey
    */
-  public async validateField(fieldKey: string): Promise<any> {
-    if (!this.hasField(fieldKey)) {
+  public async $validateField(fieldKey: string): Promise<any> {
+    if (!this.$hasField(fieldKey)) {
       warn(`\`${fieldKey}\` is not a valid field`)
 
       return Promise.resolve()
@@ -254,9 +254,9 @@ export class Form {
   /**
    * validate all the fields of the form
    */
-  public validateAll(): Promise<any> {
+  public $validateAll(): Promise<any> {
     const promises = Object.keys(this.$initialValues).map(fieldKey => {
-      return this.validateField(fieldKey)
+      return this.$validateField(fieldKey)
     })
 
     return Promise.all(promises)
@@ -267,8 +267,8 @@ export class Form {
    *
    * @param fieldKey
    */
-  public isValidating(fieldKey: string | null = null) {
-    if (fieldKey && !this.hasField(fieldKey)) {
+  public $isValidating(fieldKey: string | null = null) {
+    if (fieldKey && !this.$hasField(fieldKey)) {
       warn(`\`${fieldKey}\` is not a valid field`)
     }
 
@@ -284,15 +284,15 @@ export class Form {
    *
    * @param fieldKey
    */
-  public isDirty(fieldKey: string | null = null): boolean {
+  public $isDirty(fieldKey: string | null = null): boolean {
     if (fieldKey) {
-      return this.isFieldDirty(fieldKey)
+      return this.$isFieldDirty(fieldKey)
     }
 
     let dirty = false
 
     for (let originalFieldKey in this.$initialValues) {
-      if (this.isFieldDirty(originalFieldKey)) {
+      if (this.$isFieldDirty(originalFieldKey)) {
         dirty = true
         break
       }
@@ -306,8 +306,8 @@ export class Form {
    *
    * @param fieldKey
    */
-  public isFieldDirty(fieldKey: string): boolean {
-    if (!this.hasField(fieldKey)) {
+  public $isFieldDirty(fieldKey: string): boolean {
+    if (!this.$hasField(fieldKey)) {
       warn(`\`${fieldKey}\` is not a valid field`)
 
       return false
@@ -321,8 +321,8 @@ export class Form {
    *
    * @param fieldKey
    */
-  public fieldChanged(fieldKey: string): Form {
-    if (!this.hasField(fieldKey)) {
+  public $fieldChanged(fieldKey: string): Form {
+    if (!this.$hasField(fieldKey)) {
       warn(`\`${fieldKey}\` is not a valid field`)
 
       return this
@@ -341,8 +341,8 @@ export class Form {
    *
    * @param fieldKey
    */
-  public fieldFocused(fieldKey: string): Form {
-    if (!this.hasField(fieldKey)) {
+  public $fieldFocused(fieldKey: string): Form {
+    if (!this.$hasField(fieldKey)) {
       warn(`\`${fieldKey}\` is not a valid field`)
 
       return this
@@ -359,8 +359,8 @@ export class Form {
    *
    * @param fieldKey
    */
-  public fieldBlurred(fieldKey: string): Form {
-    if (!this.hasField(fieldKey)) {
+  public $fieldBlurred(fieldKey: string): Form {
+    if (!this.$hasField(fieldKey)) {
       warn(`\`${fieldKey}\` is not a valid field`)
 
       return this
@@ -370,7 +370,7 @@ export class Form {
       this.$onFocus = null
     }
 
-    this.$options.validation.onFieldBlurred && this.validateField(fieldKey)
+    this.$options.validation.onFieldBlurred && this.$validateField(fieldKey)
 
     return this
   }
@@ -381,7 +381,7 @@ export class Form {
    *
    * @param callback
    */
-  public submit(callback: SubmitCallback): Promise<any> {
+  public $submit(callback: SubmitCallback): Promise<any> {
     let chain: any[] = [
       () => callback(this),
       null,

--- a/src/core/Form.ts
+++ b/src/core/Form.ts
@@ -172,8 +172,8 @@ export class Form {
    * Returns FormData object with the form values,
    * this one is for the use of file upload and other.
    */
-  public valuesAsFormData(): FormData {
-    const values = this.values()
+  public $valuesAsFormData(): FormData {
+    const values = this.$values()
     const formData = new FormData()
 
     for (let key in values) {
@@ -192,8 +192,8 @@ export class Form {
   /**
    * returns the form values as a json string.
    */
-  public valuesAsJson(): string {
-    return JSON.stringify(this.values())
+  public $valuesAsJson(): string {
+    return JSON.stringify(this.$values())
   }
 
   /**

--- a/src/core/Form.ts
+++ b/src/core/Form.ts
@@ -84,7 +84,7 @@ export class Form {
    * holds the debounced version of `validateField` method the debounce time is
    * pre defined in the `$options` prop
    */
-  public debouncedValidateField: Function
+  public $debouncedValidateField: Function
 
   /**
    * constructor of the class
@@ -115,7 +115,7 @@ export class Form {
    */
   public $assignOptions(options: Options) {
     this.$options = generateOptions(this.$options, options)
-    this.debouncedValidateField = generateDebouncedValidateField(this)
+    this.$debouncedValidateField = generateDebouncedValidateField(this)
 
     return this
   }
@@ -331,7 +331,7 @@ export class Form {
     this.$options.validation.unsetFieldErrorsOnFieldChange &&
       this.$errors.unset(fieldKey)
     this.$options.validation.onFieldChanged &&
-      this.debouncedValidateField(fieldKey)
+      this.$debouncedValidateField(fieldKey)
 
     return this
   }

--- a/src/helpers/generateDebouncedValidateField.ts
+++ b/src/helpers/generateDebouncedValidateField.ts
@@ -9,7 +9,7 @@ import { Form } from '../core/Form'
  */
 export default (form: Form): Function => {
   return debounce(
-    form.validateField.bind(form),
+    form.$validateField.bind(form),
     form.$options.validation.debouncedValidateFieldTime
   )
 }

--- a/src/interceptors/beforeSubmission.ts
+++ b/src/interceptors/beforeSubmission.ts
@@ -8,7 +8,7 @@ import { InterceptorHandler } from '../types/Interceptors'
 export const validateForm: InterceptorHandler = {
   fulfilled: (form: Form): Promise<any> => {
     if (form.$options.validation.onSubmission) {
-      return form.validate().then(() => {
+      return form.$validate().then(() => {
         if (form.$errors.any()) {
           return Promise.reject({ message: 'Form is invalid.' })
         }

--- a/src/interceptors/submissionComplete.ts
+++ b/src/interceptors/submissionComplete.ts
@@ -31,7 +31,7 @@ export const clearForm: InterceptorHandler = {
 
     form.$options.successfulSubmission.clearErrors && form.$errors.clear()
     form.$options.successfulSubmission.clearTouched && form.$touched.clear()
-    form.$options.successfulSubmission.resetValues && form.resetValues()
+    form.$options.successfulSubmission.resetValues && form.$resetValues()
 
     return Promise.resolve(response)
   },

--- a/tests/core/Form/Form.events.spec.ts
+++ b/tests/core/Form/Form.events.spec.ts
@@ -19,12 +19,12 @@ describe('Form.events.ts', () => {
       },
     })
 
-    form.debouncedValidateField = jest.fn()
+    form.$debouncedValidateField = jest.fn()
 
     form.$fieldChanged('first_name')
 
-    expect(form.debouncedValidateField).toHaveBeenCalledTimes(1)
-    expect(form.debouncedValidateField).toHaveBeenCalledWith('first_name')
+    expect(form.$debouncedValidateField).toHaveBeenCalledTimes(1)
+    expect(form.$debouncedValidateField).toHaveBeenCalledWith('first_name')
 
     form.$assignOptions({
       validation: {
@@ -32,11 +32,11 @@ describe('Form.events.ts', () => {
       },
     })
 
-    form.debouncedValidateField = jest.fn()
+    form.$debouncedValidateField = jest.fn()
 
     form.$fieldChanged('first_name')
 
-    expect(form.debouncedValidateField).toHaveBeenCalledTimes(0)
+    expect(form.$debouncedValidateField).toHaveBeenCalledTimes(0)
   })
 
   it('should clear field errors after field changed', () => {

--- a/tests/core/Form/Form.events.spec.ts
+++ b/tests/core/Form/Form.events.spec.ts
@@ -21,12 +21,12 @@ describe('Form.events.ts', () => {
 
     form.debouncedValidateField = jest.fn()
 
-    form.fieldChanged('first_name')
+    form.$fieldChanged('first_name')
 
     expect(form.debouncedValidateField).toHaveBeenCalledTimes(1)
     expect(form.debouncedValidateField).toHaveBeenCalledWith('first_name')
 
-    form.assignOptions({
+    form.$assignOptions({
       validation: {
         onFieldChanged: false,
       },
@@ -34,7 +34,7 @@ describe('Form.events.ts', () => {
 
     form.debouncedValidateField = jest.fn()
 
-    form.fieldChanged('first_name')
+    form.$fieldChanged('first_name')
 
     expect(form.debouncedValidateField).toHaveBeenCalledTimes(0)
   })
@@ -46,17 +46,17 @@ describe('Form.events.ts', () => {
       },
     })
 
-    form.fieldChanged('first_name')
+    form.$fieldChanged('first_name')
 
     expect(form.$errors.unset).toHaveBeenCalledTimes(0)
 
-    form.assignOptions({
+    form.$assignOptions({
       validation: {
         unsetFieldErrorsOnFieldChange: true,
       },
     })
 
-    form.fieldChanged('first_name')
+    form.$fieldChanged('first_name')
 
     expect(form.$errors.unset).toHaveBeenCalledTimes(1)
     expect(form.$errors.unset).toHaveBeenCalledWith('first_name')
@@ -65,7 +65,7 @@ describe('Form.events.ts', () => {
   it('should push to touched and set $onFocus when field is on focus', () => {
     let form = new Form(data)
 
-    form.fieldFocused('first_name')
+    form.$fieldFocused('first_name')
 
     expect(form.$onFocus).toBe('first_name')
     expect(form.$touched.push).toHaveBeenCalledTimes(1)
@@ -79,25 +79,25 @@ describe('Form.events.ts', () => {
       },
     })
 
-    form.validateField = jest.fn()
+    form.$validateField = jest.fn()
     form.$onFocus = 'first_name'
 
-    form.fieldBlurred('first_name')
+    form.$fieldBlurred('first_name')
 
     expect(form.$onFocus).toBe(null)
-    expect(form.validateField).toHaveBeenCalledTimes(0)
+    expect(form.$validateField).toHaveBeenCalledTimes(0)
 
-    form.assignOptions({
+    form.$assignOptions({
       validation: {
         onFieldBlurred: true,
       },
     })
     form.$onFocus = 'last_name'
-    form.fieldBlurred('first_name')
+    form.$fieldBlurred('first_name')
 
     expect(form.$onFocus).toBe('last_name')
-    expect(form.validateField).toHaveBeenCalledTimes(1)
-    expect(form.validateField).toHaveBeenCalledWith('first_name')
+    expect(form.$validateField).toHaveBeenCalledTimes(1)
+    expect(form.$validateField).toHaveBeenCalledWith('first_name')
   })
 
   it('should warn if field not exists in fieldBlurred, fieldChanged and fieldFocused methods', () => {
@@ -105,17 +105,17 @@ describe('Form.events.ts', () => {
 
     let form = new Form(data)
 
-    form.fieldChanged('some_field_1')
+    form.$fieldChanged('some_field_1')
     expect(warnMock).toHaveBeenCalledTimes(1)
 
     warnMock.mockClear()
 
-    form.fieldBlurred('some_field_2')
+    form.$fieldBlurred('some_field_2')
     expect(warnMock).toHaveBeenCalledTimes(1)
 
     warnMock.mockClear()
 
-    form.fieldFocused('some_field_3')
+    form.$fieldFocused('some_field_3')
     expect(warnMock).toHaveBeenCalledTimes(1)
   })
 })

--- a/tests/core/Form/Form.interceptors.spec.ts
+++ b/tests/core/Form/Form.interceptors.spec.ts
@@ -15,7 +15,7 @@ describe('Form.interceptors.ts', () => {
 
     let callback = jest.fn(() => Promise.resolve('yay!'))
 
-    await form.submit(callback)
+    await form.$submit(callback)
 
     expect(fulfilledFunc).toHaveBeenCalledTimes(1)
     expect(fulfilledFunc).toHaveBeenLastCalledWith({ response: 'yay!', form })
@@ -28,7 +28,7 @@ describe('Form.interceptors.ts', () => {
 
     callback = jest.fn(() => Promise.reject('Oh...'))
 
-    await form.submit(callback)
+    await form.$submit(callback)
 
     expect(rejectedFunc).toHaveBeenCalledTimes(1)
     expect(rejectedFunc).toHaveBeenLastCalledWith({ error: 'Oh...', form })
@@ -48,7 +48,7 @@ describe('Form.interceptors.ts', () => {
 
     let callback = jest.fn(() => Promise.resolve('yay!'))
 
-    await form.submit(callback)
+    await form.$submit(callback)
 
     expect(fulfilledFunc).toHaveBeenCalledTimes(1)
     expect(fulfilledFunc).toHaveBeenLastCalledWith(form)
@@ -62,7 +62,7 @@ describe('Form.interceptors.ts', () => {
     form.$interceptors.beforeSubmission.use(() => Promise.reject('Error!'))
 
     try {
-      await form.submit(callback)
+      await form.$submit(callback)
     } catch (e) {
       expect(rejectedFunc).toHaveBeenCalledTimes(1)
       expect(rejectedFunc).toHaveBeenLastCalledWith('Error!')
@@ -85,13 +85,13 @@ describe('Form.interceptors.ts', () => {
     )
     form.$interceptors.submissionComplete.eject(interceptorIndex)
 
-    await form.submit(() => Promise.resolve())
+    await form.$submit(() => Promise.resolve())
 
     expect(fulfilledFunc).toHaveBeenCalledTimes(0)
     expect(rejectedFunc).toHaveBeenCalledTimes(0)
 
     try {
-      await form.submit(() => Promise.reject())
+      await form.$submit(() => Promise.reject())
     } catch (e) {
       expect(fulfilledFunc).toHaveBeenCalledTimes(0)
       expect(rejectedFunc).toHaveBeenCalledTimes(0)

--- a/tests/core/Form/Form.spec.ts
+++ b/tests/core/Form/Form.spec.ts
@@ -41,7 +41,7 @@ describe('Form.ts', () => {
     const rulesArray = [() => true]
     const isDeveloperRulesArray = [() => false]
 
-    const assignOptionsSpy = jest.spyOn(Form.prototype, 'assignOptions')
+    const assignOptionsSpy = jest.spyOn(Form.prototype, '$assignOptions')
 
     let form = new Form({
       first_name: {
@@ -112,7 +112,7 @@ describe('Form.ts', () => {
       successfulSubmission: { clearErrors: false },
     }
 
-    form.assignOptions(newOptions)
+    form.$assignOptions(newOptions)
 
     expect(form.$options).toEqual(generateOptions(defaultOptions, newOptions))
     expect(generateDebouncedValidateField).toHaveBeenLastCalledWith(form)
@@ -127,7 +127,7 @@ describe('Form.ts', () => {
 
     form.not_real_prop = 'Somthing'
 
-    expect(form.values()).toEqual({
+    expect(form.$values()).toEqual({
       ...data,
       first_name: 'Nevo',
       last_name: 'Golan',
@@ -172,9 +172,9 @@ describe('Form.ts', () => {
     form.first_name = 'Nevo'
     form.last_name = 'Golan'
 
-    form.resetValues()
+    form.$resetValues()
 
-    expect(form.values()).toEqual(data)
+    expect(form.$values()).toEqual(data)
   })
 
   it('should fill the form with new values', () => {
@@ -186,9 +186,9 @@ describe('Form.ts', () => {
       not_real_prop: 'Somthing',
     }
 
-    form.fill(newData)
+    form.$fill(newData)
 
-    expect(form.values()).toEqual(
+    expect(form.$values()).toEqual(
       Object.assign({}, data, {
         first_name: 'Nevo',
         last_name: 'Golan',
@@ -244,8 +244,8 @@ describe('Form.ts', () => {
 
     form.first_name = 'something else'
 
-    expect(form.isFieldDirty('first_name')).toBe(true)
-    expect(form.isFieldDirty('last_name')).toBe(false)
+    expect(form.$isFieldDirty('first_name')).toBe(true)
+    expect(form.$isFieldDirty('last_name')).toBe(false)
   })
 
   it('should warn if field key that passed to isDirtyField is not exists', () => {
@@ -253,7 +253,7 @@ describe('Form.ts', () => {
 
     let form = new Form({ name: null })
 
-    form.isFieldDirty('some_key')
+    form.$isFieldDirty('some_key')
 
     expect(warnMock).toHaveBeenCalledTimes(1)
   })
@@ -261,31 +261,31 @@ describe('Form.ts', () => {
   it('should run isFieldDirty (argument passes to "isDirty")', () => {
     let form = new Form(data) as Form & FormData
 
-    form.isFieldDirty = jest.fn(() => false)
+    form.$isFieldDirty = jest.fn(() => false)
 
-    let res = form.isDirty('first_name')
-    expect(form.isFieldDirty).toHaveBeenCalledWith('first_name')
+    let res = form.$isDirty('first_name')
+    expect(form.$isFieldDirty).toHaveBeenCalledWith('first_name')
     expect(res).toBe(false)
   })
 
   it('should determine if the whole form is dirty or not', () => {
     let form = new Form(data) as Form & FormData
 
-    expect(form.isDirty()).toBe(false)
+    expect(form.$isDirty()).toBe(false)
 
     form.last_name = 'somthing else'
 
-    expect(form.isDirty()).toBe(true)
+    expect(form.$isDirty()).toBe(true)
   })
 
   it('should reset all the form state', () => {
     let form = new Form(data)
 
-    form.resetValues = jest.fn()
+    form.$resetValues = jest.fn()
 
-    form.reset()
+    form.$reset()
 
-    expect(form.resetValues).toHaveBeenCalledTimes(1)
+    expect(form.$resetValues).toHaveBeenCalledTimes(1)
     expect(form.$errors.clear).toHaveBeenCalledTimes(1)
     expect(form.$touched.clear).toHaveBeenCalledTimes(1)
   })

--- a/tests/core/Form/Form.spec.ts
+++ b/tests/core/Form/Form.spec.ts
@@ -143,7 +143,7 @@ describe('Form.ts', () => {
 
     form.not_real_prop = 'Somthing'
 
-    const formData = form.valuesAsFormData()
+    const formData = form.$valuesAsFormData()
 
     expect(formData).toBeInstanceOf(FormData)
     expect(formData.get('first_name')).toBe('Nevo')
@@ -161,9 +161,9 @@ describe('Form.ts', () => {
 
     form.not_real_prop = 'Somthing'
 
-    const valueAsJson = form.valuesAsJson()
+    const valueAsJson = form.$valuesAsJson()
 
-    expect(valueAsJson).toBe(JSON.stringify(form.values()))
+    expect(valueAsJson).toBe(JSON.stringify(form.$values()))
   })
 
   it('should resetValues the values of the form', () => {

--- a/tests/core/Form/Form.spec.ts
+++ b/tests/core/Form/Form.spec.ts
@@ -116,7 +116,7 @@ describe('Form.ts', () => {
 
     expect(form.$options).toEqual(generateOptions(defaultOptions, newOptions))
     expect(generateDebouncedValidateField).toHaveBeenLastCalledWith(form)
-    expect(form.debouncedValidateField).toBe('fakeResponse')
+    expect(form.$debouncedValidateField).toBe('fakeResponse')
   })
 
   it('should returns the values on call', function() {

--- a/tests/core/Form/Form.submit.spec.ts
+++ b/tests/core/Form/Form.submit.spec.ts
@@ -14,7 +14,7 @@ describe('Form.submit.ts', () => {
       data: {},
     }
 
-    form.resetValues = jest.fn()
+    form.$resetValues = jest.fn()
 
     expect.assertions(6)
 
@@ -24,12 +24,12 @@ describe('Form.submit.ts', () => {
       return Promise.resolve(responseParam)
     })
 
-    let response = await form.submit(mockCallable)
+    let response = await form.$submit(mockCallable)
 
     expect(mockCallable.mock.calls.length).toBe(1)
     expect(form.$errors.clear).toHaveBeenCalledTimes(1)
     expect(form.$touched.clear).toHaveBeenCalledTimes(1)
-    expect(form.resetValues).toHaveBeenCalledTimes(1)
+    expect(form.$resetValues).toHaveBeenCalledTimes(1)
     expect(response).toEqual({ form, response: responseParam })
   })
 
@@ -45,7 +45,7 @@ describe('Form.submit.ts', () => {
     expect.assertions(2)
 
     try {
-      await form.submit(mockCallable)
+      await form.$submit(mockCallable)
     } catch (e) {
       expect(mockCallable.mock.calls.length).toBe(1)
       expect(e).toEqual({ error: responseParam, form })
@@ -69,13 +69,13 @@ describe('Form.submit.ts', () => {
     )
     form.$errors.any = jest.fn(() => true)
 
-    const validateSpy = jest.spyOn(form, 'validate')
+    const validateSpy = jest.spyOn(form, '$validate')
     const callback = jest.fn(() => Promise.resolve())
 
     expect.assertions(5)
 
     try {
-      await form.submit(callback)
+      await form.$submit(callback)
     } catch (e) {
       expect(validateSpy).toBeCalledTimes(1)
       expect(e.hasOwnProperty('error')).toBe(true)
@@ -97,9 +97,9 @@ describe('Form.submit.ts', () => {
       }
     )
 
-    const validateSpy = jest.spyOn(form, 'validate')
+    const validateSpy = jest.spyOn(form, '$validate')
 
-    await form.submit(() => Promise.resolve())
+    await form.$submit(() => Promise.resolve())
 
     expect(validateSpy).toBeCalledTimes(0)
   })
@@ -107,12 +107,12 @@ describe('Form.submit.ts', () => {
   it('should set $submitting as true if submit method is called', () => {
     let form = new Form({}) as Form
 
-    form.validate = jest.fn(() => Promise.resolve())
+    form.$validate = jest.fn(() => Promise.resolve())
 
     expect.assertions(2)
 
     return form
-      .submit(formParam => {
+      .$submit(formParam => {
         expect(formParam.$submitting).toBe(true)
 
         return new Promise(resolve => resolve('Yay!'))
@@ -128,7 +128,7 @@ describe('Form.submit.ts', () => {
     let mockCallable = jest.fn(() => Promise.resolve())
     form.$errors.any = jest.fn(() => true)
 
-    form.submit(mockCallable).catch(() => false)
+    form.$submit(mockCallable).catch(() => false)
 
     expect(form.$submitting).toBe(false)
     expect(mockCallable).toHaveBeenCalledTimes(0)
@@ -144,13 +144,13 @@ describe('Form.submit.ts', () => {
       }
     ) as Form
 
-    form.resetValues = jest.fn()
+    form.$resetValues = jest.fn()
 
-    await form.submit(() => Promise.resolve())
+    await form.$submit(() => Promise.resolve())
 
     expect(form.$errors.clear).toHaveBeenCalledTimes(1)
     expect(form.$touched.clear).toHaveBeenCalledTimes(1)
-    expect(form.resetValues).not.toHaveBeenCalled()
+    expect(form.$resetValues).not.toHaveBeenCalled()
   })
 
   it('should not clear errors after success submission if clearErrorsAfterSuccessfulSubmission option is false', async () => {
@@ -163,13 +163,13 @@ describe('Form.submit.ts', () => {
       }
     ) as Form
 
-    form.resetValues = jest.fn()
+    form.$resetValues = jest.fn()
 
-    await form.submit(() => Promise.resolve())
+    await form.$submit(() => Promise.resolve())
 
     expect(form.$errors.clear).not.toHaveBeenCalled()
     expect(form.$touched.clear).toHaveBeenCalledTimes(1)
-    expect(form.resetValues).toHaveBeenCalledTimes(1)
+    expect(form.$resetValues).toHaveBeenCalledTimes(1)
   })
 
   it('should not clear touched after success submission if successfulSubmission.clearTouched set to false', async () => {
@@ -182,12 +182,12 @@ describe('Form.submit.ts', () => {
       }
     ) as Form & FormData
 
-    form.resetValues = jest.fn()
+    form.$resetValues = jest.fn()
 
-    await form.submit(() => Promise.resolve())
+    await form.$submit(() => Promise.resolve())
 
     expect(form.$errors.clear).toHaveBeenCalledTimes(1)
     expect(form.$touched.clear).not.toHaveBeenCalled()
-    expect(form.resetValues).toHaveBeenCalledTimes(1)
+    expect(form.$resetValues).toHaveBeenCalledTimes(1)
   })
 })

--- a/tests/core/Form/Form.validation.spec.ts
+++ b/tests/core/Form/Form.validation.spec.ts
@@ -20,7 +20,7 @@ describe('Form.validation.ts', () => {
       Promise.reject(new FieldValidationError(['error']))
     )
 
-    await form.validateField('name')
+    await form.$validateField('name')
 
     expect(form.$errors.unset).toHaveBeenCalledTimes(1)
     expect(form.$errors.unset).toBeCalledWith('name')
@@ -38,7 +38,7 @@ describe('Form.validation.ts', () => {
 
     form.$validator.validateField = jest.fn(() => Promise.resolve())
 
-    await form.validateField('name')
+    await form.$validateField('name')
     expect(form.$errors.push).toHaveBeenCalledTimes(0)
     expect(form.$errors.unset).toHaveBeenCalledTimes(1)
     expect(form.$errors.unset).toBeCalledWith('name')
@@ -49,7 +49,7 @@ describe('Form.validation.ts', () => {
 
     let form = new Form({ name: null })
 
-    await form.validateField('first_name')
+    await form.$validateField('first_name')
 
     expect(warnSpy).toHaveBeenCalledTimes(1)
     warnSpy.mockClear()
@@ -67,35 +67,35 @@ describe('Form.validation.ts', () => {
       },
     })
 
-    form.validateField = jest
+    form.$validateField = jest
       .fn()
       .mockReturnValueOnce(Promise.resolve())
       .mockReturnValueOnce(Promise.resolve())
 
-    await form.validateAll()
+    await form.$validateAll()
 
-    expect(form.validateField).toHaveBeenNthCalledWith(1, 'name')
-    expect(form.validateField).toHaveBeenNthCalledWith(2, 'last_name')
+    expect(form.$validateField).toHaveBeenNthCalledWith(1, 'name')
+    expect(form.$validateField).toHaveBeenNthCalledWith(2, 'last_name')
   })
 
   it('should call to validate specific field or all the fields', async () => {
     let form = new Form({ first_name: null })
 
-    form.validateAll = jest.fn()
-    form.validateField = jest.fn()
+    form.$validateAll = jest.fn()
+    form.$validateField = jest.fn()
 
-    await form.validate()
+    await form.$validate()
 
-    expect(form.validateAll).toHaveBeenCalledTimes(1)
-    expect(form.validateField).toHaveBeenCalledTimes(0)
+    expect(form.$validateAll).toHaveBeenCalledTimes(1)
+    expect(form.$validateField).toHaveBeenCalledTimes(0)
 
-    mocked(form.validateAll).mockClear()
-    mocked(form.validateField).mockClear()
+    mocked(form.$validateAll).mockClear()
+    mocked(form.$validateField).mockClear()
 
-    await form.validate('first_name')
+    await form.$validate('first_name')
 
-    expect(form.validateAll).toHaveBeenCalledTimes(0)
-    expect(form.validateField).toHaveBeenCalledTimes(1)
+    expect(form.$validateAll).toHaveBeenCalledTimes(0)
+    expect(form.$validateField).toHaveBeenCalledTimes(1)
   })
 
   it('should bubble up errors that are not FieldValidationError on validateField method', async () => {
@@ -108,7 +108,7 @@ describe('Form.validation.ts', () => {
     expect.assertions(2)
 
     try {
-      await form.validateField('name')
+      await form.$validateField('name')
     } catch (e) {
       expect(e).toBeInstanceOf(Error)
       expect(e.message).toBe('error')
@@ -120,12 +120,12 @@ describe('Form.validation.ts', () => {
 
     form.$validator.$validating.has = jest.fn(() => true)
 
-    expect(form.isValidating('name')).toBe(true)
+    expect(form.$isValidating('name')).toBe(true)
     expect(form.$validator.$validating.has).toHaveBeenCalledWith('name')
 
     form.$validator.$validating.has = jest.fn(() => false)
 
-    expect(form.isValidating('name')).toBe(false)
+    expect(form.$isValidating('name')).toBe(false)
     expect(form.$validator.$validating.has).toHaveBeenCalledWith('name')
   })
 
@@ -134,12 +134,12 @@ describe('Form.validation.ts', () => {
 
     form.$validator.$validating.any = jest.fn(() => true)
 
-    expect(form.isValidating()).toBe(true)
+    expect(form.$isValidating()).toBe(true)
     expect(form.$validator.$validating.any).toHaveBeenCalledTimes(1)
 
     form.$validator.$validating.any = jest.fn(() => false)
 
-    expect(form.isValidating()).toBe(false)
+    expect(form.$isValidating()).toBe(false)
     expect(form.$validator.$validating.any).toHaveBeenCalledTimes(1)
   })
 
@@ -148,7 +148,7 @@ describe('Form.validation.ts', () => {
 
     let form = new Form({ name: null })
 
-    form.isValidating('loYodea')
+    form.$isValidating('loYodea')
 
     expect(warnSpy).toHaveBeenCalledTimes(1)
     warnSpy.mockClear()

--- a/tests/helpers/generateDebouncedValidateField.spec.ts
+++ b/tests/helpers/generateDebouncedValidateField.spec.ts
@@ -21,6 +21,6 @@ describe('generateDebouncedValidateField.ts', () => {
     let result = generateDebouncedValidateField(form)
 
     expect(result).toBe('example')
-    expect(utils.debounce).toHaveBeenLastCalledWith(form.validateField, 500)
+    expect(utils.debounce).toHaveBeenLastCalledWith(form.$validateField, 500)
   })
 })


### PR DESCRIPTION
The idea of this refactoring is to make sure that there is no conflict between a form field prop and a method prop.

For example, you can have a prop with the name:
`reset` exact name of `reset` method, this situation can make some problems.